### PR TITLE
Fix rule reference that shows old specs

### DIFF
--- a/src/pages/docs/listings/rule.md
+++ b/src/pages/docs/listings/rule.md
@@ -2,9 +2,7 @@
   "effect": "HIDE",
   "condition": {
     "type": "LEAF",
-    "scope": {
-      "$ref": "#/properties/name"
-    },
+    "scope": "#/properties/name",
     "expectedValue": "foo"
   }
 }


### PR DESCRIPTION
Rules tripped me up until I viewed the example doc.