### PR TITLE
Use `npm start`

### DIFF
--- a/src/pages/docs/getting-started.mdx
+++ b/src/pages/docs/getting-started.mdx
@@ -14,7 +14,7 @@ This section describes how you can get quickly started with JSON Forms.
    ```
 3. Run the app with:
    ```
-   npm run start
+   npm start
    ```
 
 For more info about the seed app, please see the corresponding README file of the


### PR DESCRIPTION
`run` isn't needed with the `start` script.