### PR TITLE
Remove custom categorization data, instead load default

### DIFF
--- a/src/components/examples/Categorization.js
+++ b/src/components/examples/Categorization.js
@@ -7,12 +7,7 @@ import { createJsonFormsStore } from '../../common/store';
 
 const CategorizationExample = () => {
   const store = createJsonFormsStore({
-    data: {
-      name: 'Max Power',
-      vegetarian: true,
-      birthDate: '1956-05-12',
-      nationality: 'US'
-    },
+    data: categorization.data,
     schema: categorization.schema,
     uischema: categorization.uischema
   });

--- a/src/pages/examples/categorization.mdx
+++ b/src/pages/examples/categorization.mdx
@@ -7,6 +7,6 @@ import Categorization from '../../components/examples/Categorization'
 
 # Categorization
 
-Click the 'Vegetarian' checkbox to conditionally show a second tab.
+To show the 'Address' tab, click the  'Provide Address' checkbox. To show yet another tab, click the 'Vegetarian' checkbox.
 
 <Categorization />


### PR DESCRIPTION
Corrects the data for the categorization example.
Related PR: https://github.com/eclipsesource/jsonforms/pull/1599