### PR TITLE
Updates the version script to fetch prereleases

### DIFF
--- a/build_with_next.sh
+++ b/build_with_next.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-NEXTVERSION=$(curl --silent "https://api.github.com/repos/eclipsesource/jsonforms/releases" | grep '"tag_name":' | head -1 | sed -E 's/.*"([^"]+)".*/\1/')
+NEXTVERSION=$(curl --silent "https://api.github.com/repos/eclipsesource/jsonforms/tags" | grep '"name":' | head -1 | sed -E 's/.*"([^"]+)".*/\1/')
 
 if [[ ${NEXTVERSION:0:1} == "v" ]] ; then NEXTVERSION="${NEXTVERSION:1}"; fi
 


### PR DESCRIPTION
JSON Forms prereleases are not marked as releases on Github. Therefore
we need to check against the `tags` endpoint instead of `releases`.