### PR TITLE
Fix build warnings

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -157,6 +157,7 @@ module.exports = {
         id: 'faq',
         path: 'content/faq',
         routeBasePath: 'faq',
+        sidebarPath: require.resolve('./src/sidebars/faq.js'),
       },
     ],
     [
@@ -228,7 +229,9 @@ module.exports = {
     [
       '@easyops-cn/docusaurus-search-local',
       {
-        hashed: true
+        hashed: true,
+        docsDir: "./content/docs",
+        blogDir: "./content/news"
       },
     ]
   ],

--- a/src/css/global.scss
+++ b/src/css/global.scss
@@ -45,6 +45,9 @@ html[data-theme='light'] {
   .navbar__brand:hover {
     color: var(--background);
   }
+  .navbar__toggle {
+    color: var(--background);
+  }
   .footer--dark {
     --ifm-footer-background-color: #242526;
   }

--- a/src/sidebars/faq.js
+++ b/src/sidebars/faq.js
@@ -1,0 +1,2 @@
+module.exports = {
+};


### PR DESCRIPTION
Fixes the following warnings during build:
```
The sidebar file of docs version [current] does not exist. It is optional, but should rather be provided at /jsonforms2-website/sidebars.json
Warn: `docsDir` doesn't exist: "/jsonforms2-website/docs".
Warn: `blogDir` doesn't exist: "/jsonforms2-website/blog".
```