### PR TITLE
Fix to uischema link refs - currently breaks after page refresh

### DIFF
--- a/content/docs/uischema/uischema.mdx
+++ b/content/docs/uischema/uischema.mdx
@@ -11,6 +11,6 @@ Some UI schema elements allow an `options` property which allows for further con
 
 ## Available elements
 
-- [Controls](controls)
-- [Layouts](layouts)
-- [Rules](rules)
+- [Controls](/docs/uischema/controls)
+- [Layouts](/docs/uischema/layouts)
+- [Rules](/docs/uischema/rules)


### PR DESCRIPTION
Hi there,

I figured this one would easily go unnoticed, so I thought I'd fix it.

To reproduce this, visit this page and click on any of the 3 links (controls, layouts, rules) 
https://jsonforms.io/docs/uischema/uischema/

If you are wondering how you have never seen this before, let me explain. When you are navigating to any of these pages via the left navigation, you will land on `/docs/uischema/uischema` without the last dash (`/`). Like so:
https://jsonforms.io/docs/uischema/uischema

However, if you refresh the page while on `/docs/uischema/uischema`, the dash will be appended to the url, bringing you to (at least, it does so for me):
https://jsonforms.io/docs/uischema/uischema/

This breaks the links because, as you can see, it appends the provided path (e.g., `controls`) to the existing path, instead of replacing the second `/uischema/`.

All I've done here is update the paths in the markdown to be complete relative path so it will always replace the entire path:
`controls` → `/docs/uischema/controls`

Apologies for the over-explanation, but hopefully this helps. Thanks!

