### PR TITLE
Fix overflow issue in Demo element

### DIFF
--- a/src/components/common/Demo.js
+++ b/src/components/common/Demo.js
@@ -68,7 +68,8 @@ const TabsContainer = styled(Tabs)({
 const DemoTab = styled(TabItem)({
   borderRadius: 'var(--ifm-pre-border-radius)',
   padding: '16px',
-  border: '1px solid #eee'
+  border: '1px solid #eee',
+  overflowX: 'auto',
 });
 
 const Code = (props) => {


### PR DESCRIPTION
This PR should fix the issue https://github.com/eclipsesource/jsonforms/issues/2313

It also enhances PR https://github.com/eclipsesource/jsonforms2-website/pull/293 without showing the scrollbar all the time. Instead of using `scoll`, we use `auto` here, to hide the scrollbar when no overflow content is present:

![image](https://github.com/eclipsesource/jsonforms2-website/assets/1368405/95a165fd-c3b4-460b-a5e0-d4e07b8c12ff)

(Source: https://developer.mozilla.org/en-US/docs/Web/CSS/overflow#auto)