### PR TITLE
docs: fix broken link in what-is-jsonforms page

### DIFF
--- a/content/docs/what-is-jsonforms.mdx
+++ b/content/docs/what-is-jsonforms.mdx
@@ -97,4 +97,4 @@ JSON Forms provides default renderers for all data types, however, you can chang
 
 <GettingStartedExampleWithRatingControl />
 
-If you are interested in learning more about JSON Forms, check out the [Getting started](getting-started) section.
+If you are interested in learning more about JSON Forms, check out the [Getting started](docs/getting-started) section.


### PR DESCRIPTION
When you hover and click the `Getting started` link at the end of the [documentation homepage](https://jsonforms.io/docs) (Figure 1), it takes you to 404-page `https://jsonforms.io/getting-started` (Figure 2).

![image](https://github.com/user-attachments/assets/ed051844-ab90-4d94-bdf2-144e52f12cd4)
Figure 1

![image](https://github.com/user-attachments/assets/228aeab8-99f4-4603-8247-a57f3620c072)
Figure 2

