### PR TITLE
docs: remove `formaide` from the community projects

### DIFF
--- a/content/community/community.mdx
+++ b/content/community/community.mdx
@@ -43,7 +43,6 @@ EclipseSource bears no responsibility for the accuracy, legality or content of t
 - [JSON Forms Editor](https://jsonformseditor.io) by backoffice.plus
 - [JSON Forms AntD Renderers](https://github.com/great-expectations/jsonforms-antd-renderers) by GX Labs
 - [Jsonform Builder](https://www.jsonform-builder.com/) by Eidriahn
-- [formaide Form Editor](https://app.formaide.com/editor/forms/create) by Johannes Eriksson
 - [Flutter JSON Forms Renderer](https://github.com/pyck-ai/json-forms-renderer-flutter) by pyck.ai
 - [JSON Forms Kotlin Multiplatform](https://github.com/GerardPaligot/jsonforms-kotlin) by Gérard Paligot
 


### PR DESCRIPTION
it won't be available publicly anymore