### PR TITLE
Add Shadcn/ui Renderer to community list

### DIFF
--- a/content/community/community.mdx
+++ b/content/community/community.mdx
@@ -45,6 +45,7 @@ EclipseSource bears no responsibility for the accuracy, legality or content of t
 - [Jsonform Builder](https://www.jsonform-builder.com/) by Eidriahn
 - [Flutter JSON Forms Renderer](https://github.com/pyck-ai/json-forms-renderer-flutter) by pyck.ai
 - [JSON Forms Kotlin Multiplatform](https://github.com/GerardPaligot/jsonforms-kotlin) by Gérard Paligot
+- [Shadcn/ui Renderer](https://fragno.dev/docs/forms/shadcn-renderer) by fragno.dev
 
 You would like to see your project listed here?
 Simply open a PR against the [JSON Forms website repository](https://github.com/eclipsesource/jsonforms2-website/blob/master/content/community/community.mdx)!


### PR DESCRIPTION
I've built a react renderer that uses shadcn/ui components for rendering forms. It's open source under the MIT license.

I've linked the documentation, but a live demo is available here: https://fragno.dev/forms

Thanks!